### PR TITLE
moving jest test utils into common

### DIFF
--- a/src/__tests__/Helpers.spec.js
+++ b/src/__tests__/Helpers.spec.js
@@ -1,0 +1,15 @@
+import { firstUpperCase, atLeastOneMatch } from '../Helpers'
+
+describe('Src Helpers', () => {
+  it('sets the first character to uppercase', () => {
+    expect(firstUpperCase('aaaa')).toBe('Aaaa')
+  })
+
+  it('checks if two arrays have one element in common', () => {
+    const base = [1, 2, 2]
+    const matching = [0, 1, 3]
+    const nonMatching = [0, 3, 4]
+    expect(atLeastOneMatch(base, matching)).toBe(true)
+    expect(atLeastOneMatch(base, nonMatching)).toBe(false)
+  })
+})

--- a/src/components/SideDrawerContent/PageLink.vue
+++ b/src/components/SideDrawerContent/PageLink.vue
@@ -11,7 +11,7 @@
 
 <script>
 export default {
-  name: 'pageLink',
+  name: 'PageLink',
   props: {
     path: {
       type: String,

--- a/src/components/SideDrawerContent/__tests__/PageLink.spec.js
+++ b/src/components/SideDrawerContent/__tests__/PageLink.spec.js
@@ -1,5 +1,5 @@
 import PageLink from '../PageLink'
-import { mountQuasar } from '../../../../../test/jest/utils'
+import { mountQuasar } from '../../../../unit-tests/utils'
 import sinon from 'sinon'
 
 describe('PageLink', () => {

--- a/src/components/SideDrawerContent/__tests__/SideDrawerContent.spec.js
+++ b/src/components/SideDrawerContent/__tests__/SideDrawerContent.spec.js
@@ -1,0 +1,90 @@
+import sideDrawerContent from '../SideDrawerContent'
+import { mountQuasar } from '../../../../unit-tests/utils'
+import { generatePath } from '../../../router/Helpers'
+import types from '../../../../types'
+
+describe('SideDrawerContent', () => {
+  const wrapper = mountQuasar(sideDrawerContent, {
+    shallow: true,
+    propsData: {
+      email: 'test@mail.com',
+      drawerOpen: false,
+      orderedLinks: {
+        userManagement: [
+          'link1',
+          'link2',
+          types.links.ACTIVATE
+        ],
+        navigation: [
+          'link4',
+          'link5',
+          types.links.HOME
+        ]
+      },
+      accessRules: {
+        permission1: {
+          link1: true,
+          link2: false,
+          [types.links.ACTIVATE]: false,
+          link4: true,
+          link5: false,
+          [types.links.HOME]: false
+        },
+        permission2: {
+          link1: true,
+          link2: true,
+          [types.links.ACTIVATE]: false,
+          link4: true,
+          link5: true,
+          [types.links.HOME]: false
+        },
+        permission3: {
+          link1: false,
+          link2: false,
+          [types.links.ACTIVATE]: true,
+          link4: false,
+          link5: false,
+          [types.links.HOME]: true
+        }
+      },
+      permissions: []
+    }
+  })
+
+  it('displays a PageLink for any link if any permission corresponds to an accessRule that has value "true" for the key "link" ', () => {
+    wrapper.setProps({ permissions: ['permission1'] })
+    const pageLinksWithPermission1 = wrapper.findAll({ name: 'PageLink' })
+    expect(pageLinksWithPermission1.length).toBe(2)
+    wrapper.setProps({ permissions: ['permission1', 'permission2'] })
+    const pageLinksWithPermission1And2 = wrapper.findAll({ name: 'PageLink' })
+    expect(pageLinksWithPermission1And2.length).toBe(4)
+    wrapper.setProps({ permissions: ['permission1', 'permission2', 'permission3'] })
+    const pageLinksWithPermission12And3 = wrapper.findAll({ name: 'PageLink' })
+    expect(pageLinksWithPermission12And3.length).toBe(6)
+  })
+
+  it('generates a path for each pageLink following the rules set in common/src/router/helpers[generatePath]', () => {
+    wrapper.setProps({ permissions: ['permission1'] })
+    const pageLinksWithPermission1 = wrapper.findAll({ name: 'PageLink' })
+    expect(pageLinksWithPermission1.wrappers[0].vm.path).toBe(generatePath({ link: 'link1' }))
+    expect(pageLinksWithPermission1.wrappers[1].vm.path).toBe(generatePath({ link: 'link4' }))
+    wrapper.setProps({ permissions: ['permission3'] })
+    const pageLinksWithPermission3 = wrapper.findAll({ name: 'PageLink' })
+    expect(pageLinksWithPermission3.wrappers[0].vm.path).toBe(generatePath({ link: types.links.ACTIVATE }))
+    expect(pageLinksWithPermission3.wrappers[1].vm.path).toBe(generatePath({ link: types.links.HOME }))
+  })
+
+  it('displays userManagement links first, and navigation links second, according to their order', () => {
+    wrapper.setProps({ permissions: ['permission1', 'permission2', 'permission3'] })
+    const pageLinks = wrapper.findAll({ name: 'PageLink' })
+    const expectLabelOfNum = (num, label) => {
+      expect(pageLinks.wrappers[num].vm.label).toBe(label)
+    }
+    expectLabelOfNum(0, 'link1')
+    expectLabelOfNum(1, 'link2')
+    expectLabelOfNum(2, types.links.ACTIVATE)
+    expectLabelOfNum(3, 'link4')
+    expectLabelOfNum(4, 'link5')
+    expectLabelOfNum(5, types.links.HOME)
+  })
+})

--- a/src/components/form/__tests__/CheckboxWithValidation.spec.js
+++ b/src/components/form/__tests__/CheckboxWithValidation.spec.js
@@ -1,5 +1,5 @@
 import CheckboxWithValidation from '../CheckboxWithValidation'
-import { mountQuasar } from '../../../../../test/jest/utils'
+import { mountQuasar } from '../../../../unit-tests/utils'
 
 describe('CheckboxWithValidation', () => {
   const dummyContent = 'dummy card content'

--- a/src/components/form/__tests__/EmailWithValidation.spec.js
+++ b/src/components/form/__tests__/EmailWithValidation.spec.js
@@ -1,5 +1,5 @@
 import EmailWithValidation from '../EmailWithValidation'
-import { mountQuasar } from '../../../../../test/jest/utils'
+import { mountQuasar } from '../../../../unit-tests/utils'
 import vuelidate from '../../../../../src/boot/vuelidate'
 
 describe('mocking vuelidate', () => {

--- a/src/components/form/__tests__/InputWithValidation.spec.js
+++ b/src/components/form/__tests__/InputWithValidation.spec.js
@@ -1,5 +1,5 @@
 import InputWithValidation from '../InputWithValidation'
-import { mountQuasar } from '../../../../../test/jest/utils'
+import { mountQuasar } from '../../../../unit-tests/utils'
 
 describe('InputWithValidation', () => {
   const wrapper = mountQuasar(InputWithValidation)

--- a/src/components/form/__tests__/PasswordWithValidation.spec.js
+++ b/src/components/form/__tests__/PasswordWithValidation.spec.js
@@ -1,5 +1,5 @@
 import PasswordWithValidation from '../PasswordWithValidation'
-import { mountQuasar } from '../../../../../test/jest/utils'
+import { mountQuasar } from '../../../../unit-tests/utils'
 import vuelidate from '../../../../../src/boot/vuelidate'
 import { passwords } from '../passwordPolicy'
 

--- a/src/components/form/__tests__/ValidityIcon.spec.js
+++ b/src/components/form/__tests__/ValidityIcon.spec.js
@@ -1,5 +1,5 @@
 import ValidityIcon from '../ValidityIcon'
-import { mountQuasar } from '../../../../../test/jest/utils'
+import { mountQuasar } from '../../../../unit-tests/utils'
 
 describe('Validity Icon', () => {
   const wrapper = mountQuasar(ValidityIcon)

--- a/unit-tests/__tests__/App.spec.js
+++ b/unit-tests/__tests__/App.spec.js
@@ -1,0 +1,61 @@
+/* eslint-disable */
+/**
+ * @jest-environment jsdom
+ */
+
+import { mount, createLocalVue, shallowMount } from '@vue/test-utils'
+import QBUTTON from './demo/QBtn-demo.vue'
+import * as All from 'quasar'
+// import langEn from 'quasar/lang/en-us' // change to any language you wish! => this breaks wallaby :(
+const { Quasar, date } = All
+
+const components = Object.keys(All).reduce((object, key) => {
+  const val = All[key]
+  if (val && val.component && val.component.name != null) {
+    object[key] = val
+  }
+  return object
+}, {})
+
+describe('Mount Quasar', () => {
+  const localVue = createLocalVue()
+  localVue.use(Quasar, { components }) // , lang: langEn
+
+  const wrapper = mount(QBUTTON, {
+    localVue
+  })
+  const vm = wrapper.vm
+
+  it('passes the sanity check and creates a wrapper', () => {
+    expect(wrapper.isVueInstance()).toBe(true)
+  })
+
+  it('has a created hook', () => {
+    expect(typeof vm.increment).toBe('function')
+  })
+
+  it('accesses the shallowMount', () => {
+    expect(vm.$el.textContent).toContain('rocket muffin')
+    expect(wrapper.text()).toContain('rocket muffin') // easier
+    expect(wrapper.find('p').text()).toContain('rocket muffin')
+  })
+
+  it('sets the correct default data', () => {
+    expect(typeof vm.counter).toBe('number')
+    const defaultData2 = QBUTTON.data()
+    expect(defaultData2.counter).toBe(0)
+  })
+
+  it('correctly updates data when button is pressed', () => {
+    const button = wrapper.find('button')
+    button.trigger('click')
+    expect(vm.counter).toBe(1)
+  })
+
+  it('formats a date without throwing exception', () => {
+    // test will automatically fail if an exception is thrown
+    // MMMM and MMM require that a language is 'installed' in Quasar
+    let formattedString = date.formatDate(Date.now(), 'YYYY MMMM MMM DD')
+    console.log('formattedString', formattedString)
+  })
+})

--- a/unit-tests/__tests__/demo/QBtn-demo.vue
+++ b/unit-tests/__tests__/demo/QBtn-demo.vue
@@ -1,0 +1,24 @@
+<template>
+<div>
+  <p class="textContent">{{ input }}</p>
+  <span>{{ counter }}</span>
+  <q-btn id="mybutton" @click="increment()"></q-btn>
+</div>
+</template>
+
+<script>
+export default {
+  name: 'QBUTTON',
+  data () {
+    return {
+      counter: 0,
+      input: 'rocket muffin'
+    }
+  },
+  methods: {
+    increment () {
+      this.counter++
+    }
+  }
+}
+</script>

--- a/unit-tests/utils/index.js
+++ b/unit-tests/utils/index.js
@@ -1,0 +1,84 @@
+// this is mapped in jest.config.js to resolve @vue/test-utils
+import { createLocalVue, mount, shallowMount } from 'test-utils'
+import Vuex from 'vuex'
+import Quasar, { Cookies } from 'quasar'
+
+import { createStore } from './store'
+import { initRouter } from './router'
+
+const mockSsrContext = () => {
+  return {
+    req: {
+      headers: {}
+    },
+    res: {
+      setHeader: () => undefined
+    }
+  }
+}
+
+// https://eddyerburgh.me/mock-vuex-in-vue-unit-tests
+export const mountQuasar = (component, options = {}) => {
+  const localVue = createLocalVue()
+  const app = {}
+
+  localVue.use(Vuex)
+  localVue.use(Quasar)
+  const store = createStore(options)
+  const router = initRouter(localVue, options)
+
+  // mock vue-i18n
+  const $t = t => t
+  const $tc = tc => tc
+  const $n = n => n
+  const $d = d => d
+  let mocks = { $t, $tc, $n, $d }
+
+  if (options) {
+    const ssrContext = options.ssr ? mockSsrContext() : null
+
+    if (options.cookies) {
+      const cookieStorage = ssrContext ? Cookies.parseSSR(ssrContext) : Cookies
+      const cookies = options.cookies
+      Object.keys(cookies).forEach(key => {
+        cookieStorage.set(key, cookies[key])
+      })
+    }
+
+    if (options.boot) {
+      options.boot.forEach(plugin => {
+        plugin({ app, store, router, Vue: localVue, ssrContext })
+      })
+    }
+
+    if (options.mocks) {
+      mocks = {...mocks, ...options.mocks}
+    }
+  }
+
+  const mountOptions = {
+    localVue: localVue,
+    store,
+    router,
+    mocks,
+    propsData: options.propsData,
+    slots: options.slots,
+
+    // Injections for Components with a QPage root Element
+    provide: {
+      pageContainer: true,
+      layout: {
+        header: {},
+        right: {},
+        footer: {},
+        left: {}
+      }
+    }
+  }
+
+  if (options.shallow) {
+    return shallowMount(component, mountOptions)
+  } else {
+    return mount(component, mountOptions)
+  }
+}

--- a/unit-tests/utils/router.js
+++ b/unit-tests/utils/router.js
@@ -1,0 +1,10 @@
+import VueRouter from 'vue-router'
+
+export function initRouter (localVue, options) {
+  if (options.mocks && options.mocks.$route) {
+    return {}
+  } else {
+    localVue.use(VueRouter)
+    return new VueRouter()
+  }
+}

--- a/unit-tests/utils/store.js
+++ b/unit-tests/utils/store.js
@@ -1,0 +1,96 @@
+import Vuex from 'vuex'
+import sinon from 'sinon'
+
+/**
+ * if the action <actionName> is dispatched
+ * with argument <arg1Name> = <arg1Value1>
+ * and argument <arg2Name> = <arg2Value1>
+ * it resolves with response <responseValue1>
+ *
+ * if the action <actionName> is dispatched
+ * with argument <arg1Name> = <arg1Value2>
+ * it rejects with error <errorMessage>
+ *
+ * if the action <actionName> is dispatched
+ * without argument
+ * it resolves with response <responseValue2>
+ *
+ * store: {
+      actions: {
+        actionName: [
+          {
+            args: {
+              arg1Name: arg1Value1,
+              arg2Name: arg2Value1
+            },
+            resolve: responseValue1
+          },
+          {
+            args: {
+              arg1Name: arg1Value2
+            },
+            reject: errorMessage
+          },
+          {
+            resolve: responseValue2
+          }
+        ]
+      }
+    }
+ */
+
+function createState (state) {
+  return state
+}
+
+function createGetters (getters) {
+  return getters
+}
+
+function createMutations (mutations) {
+  return mutations
+}
+
+function createActions (actions) {
+  return Object.entries(actions).reduce((builtActions, actionStates) => {
+    var stub = sinon.stub()
+    const name = actionStates[0]
+    const states = actionStates[1]
+    for (var i = 0; i < states.length; i++) {
+      if (states[i].args) {
+        if (states[i].resolve) {
+          stub.withArgs(sinon.match(Object), sinon.match(states[i].args)).resolves(states[i].resolve)
+        } else if (states[i].reject) {
+          stub.withArgs(sinon.match(Object), sinon.match(states[i].args)).rejects(states[i].reject)
+        } else console.error('Action format error')
+      } else {
+        if (states[i].resolve) {
+          stub.resolves(states[i].resolve)
+        } else if (states[i].reject) {
+          stub.rejects(states[i].reject)
+        } else console.error('Action format error')
+      }
+    }
+    builtActions = { ...builtActions, [name]: stub }
+    return builtActions
+  }, {})
+}
+
+export function createStore (options) {
+  let storeOptions = {}
+  if (options.store) {
+    if (options.store.state) {
+      storeOptions = { ...storeOptions, state: createState(options.store.state) }
+    }
+    if (options.store.getters) {
+      storeOptions = { ...storeOptions, getters: createGetters(options.store.getters) }
+    }
+    if (options.store.mutations) {
+      storeOptions = { ...storeOptions, mutations: createMutations(options.store.mutations) }
+    }
+    if (options.store.actions) {
+      storeOptions = { ...storeOptions, actions: createActions(options.store.actions) }
+    }
+  }
+  return new Vuex.Store(storeOptions)
+}

--- a/unit-tests/utils/stub.css
+++ b/unit-tests/utils/stub.css
@@ -1,0 +1,9 @@
+/* for mocking out css files in jest.config.js */
+/*
+
+	moduleNameMapper: {
+    ...
+    '.*css$': '<rootDir>/test/jest/utils/stub.css'
+  },
+
+ */


### PR DESCRIPTION
[Recap of our workflow](https://github.com/softozor/shopozor-consumer-frontend#pull-requests) 

# Prerequisites

- [ ] You have configured the triggering of the pre-commit hook on your local repository's clone.
- [ ] You have covered your code with unit and acceptance tests
- [ ] The feature you have implemented has no tag `@wip` any more
- [ ] None of the feature files have a tag `@current` or `@focus`

# Changes

`common/src/test` has been moved to `common/test`
`consumer-fontend/test/jest/utils` has been moved to `common/unit-tests/utils`

# How to use the feature

no new feature

# Additional notes

@zadigus Le format automatique des pull request n'était pas là lors de la création de celle-ci, contrairement au consumer-frontend. J'ai fait un copier-coller.